### PR TITLE
docs/example: use correct provider

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     twsaws = {
-      version = "0.1"
-      source  = "github.com/truewhitespace/twsaws"
+      version = "1.0.0"
+      source  = "truewhitespace/twsaws"
     }
   }
 }

--- a/examples/some-user/main.tf
+++ b/examples/some-user/main.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     twsaws = {
-      version = "0.1"
-      source  = "github.com/truewhitespace/twsaws"
+      version = "1.0.0"
+      source  = "truewhitespace/twsaws"
     }
   }
 }


### PR DESCRIPTION
Updates the example to use version 1.0.0 of the provider with the correct provider name to download from primary reigstry.